### PR TITLE
feat(buttondown): route newsletters to Buttondown, skip WordPress on PR

### DIFF
--- a/.github/workflows/buttondown-sync.yml
+++ b/.github/workflows/buttondown-sync.yml
@@ -1,0 +1,52 @@
+name: Buttondown Sync (create draft emails on merge)
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  buttondown-sync:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create Buttondown draft emails
+        env:
+          BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node src/index.js merge

--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
 This holds the content for https://distractedfortune.com
 
+Publishing workflow
+-------------------
+
+Content is organized into two types, detected by directory path:
+
+**Articles** (`content/posts/YYYYMMDD_Title/draft.md`)
+- On PR open: a draft is created (or updated) in WordPress.
+- On PR merge: a Buttondown draft email is created containing the post excerpt and a link to the WordPress post. You review and send it manually in Buttondown.
+
+**Newsletters** (`content/newsletters/YYYYMMDD_Title/draft.md`)
+- On PR open: nothing happens — newsletters never go to WordPress.
+- On PR merge: a Buttondown draft email is created with the full newsletter content converted to HTML. You review and send it manually in Buttondown.
+
+Required GitHub Actions secrets
+- `BOT_USERNAME` / `BOT_PASSWORD` — WordPress credentials for JWT auth (articles only)
+- `WP_URL` — WordPress site URL (articles only)
+- `WP_USER` — WordPress username (articles only)
+- `BUTTONDOWN_API_KEY` — Buttondown API key (Settings → API Keys in Buttondown)
+
 CI and forked pull requests
---------------------------
+----------------------------
 
 The wp-sync workflow needs repository secrets (BOT_USERNAME and BOT_PASSWORD) to fetch a JWT token for the WordPress site. GitHub does not expose repository secrets to workflows triggered by pull requests from forks. If you open a PR from a fork, the workflow will fail early with a clear error message.
 

--- a/documentation/ISSUE_28_NEWSLETTER.md
+++ b/documentation/ISSUE_28_NEWSLETTER.md
@@ -1,0 +1,45 @@
+## Summary
+Transition all blog post emailing from WordPress/Jetpack to Buttondown. The new workflow will distinguish between "articles" (published to WordPress and excerpt/link emailed) and "newsletters" (emailed via Buttondown only, not published to WordPress).
+
+## Background
+- Buttondown account has been created.
+- All Jetpack subscribers have been migrated to Buttondown.
+- Posts are categorized as either "articles" or "newsletters" in the repo.
+   - **Articles:** Currently sent to WordPress, post-edited, and emailed via Jetpack/WordPress.
+   - **Newsletters:** Currently also sent to WordPress and emailed, but should not be.
+- Present workflow sends everything to WordPress on PR and you handle emailing/posting manually from there.
+
+## Goal
+- On PR (for either an article or newsletter):
+   - **Only articles:** Should be pushed to WordPress for preview/publication. Newsletters should NOT go to WordPress at all, only exist in the repo/PR.
+- On PR merged:
+   - **Articles:** Only an excerpt and link should be emailed via Buttondown (not full content).
+   - **Newsletters:** The full content should be emailed to subscribers via Buttondown, but not published to WordPress.
+- **Optional (ideal for now):** After PR merge, create a draft in Buttondown to review layout and appearance before sending. You do the final "send" manually in Buttondown until the workflow is totally trusted.
+
+## Implementation Tasks
+1. Update GitHub Actions/workflows:
+    - Detect if content is an article or newsletter based on path/metadata/frontmatter.
+    - On PR open:
+         - If article, create draft post on WordPress only.
+         - If newsletter, do nothing with WordPress.
+    - On PR merge:
+        - If article, send excerpt + link via Buttondown (automate via API and repo secrets). Optionally, create as draft in Buttondown for review.
+        - If newsletter, send full content via Buttondown. Optionally, create as draft in Buttondown.
+2. Configure and securely store Buttondown API secrets in repo/Actions.
+3. Update documentation/readme for new publishing process for both article & newsletter workflows.
+4. Clean up/deprecate old Jetpack/WordPress email logic.
+
+## Acceptance Criteria
+- Only articles go to WordPress; newsletters never appear in WordPress.
+- On merge, Buttondown emails are created for both articles (excerpt & link) and newsletters (full content).
+- Buttondown emails can be reviewed/sent manually during the transition.
+- No emails are sent by Jetpack/WordPress.
+
+## Notes
+- Retain the ability to manually trigger/override in Buttondown until you're confident with automation.
+- Old issue (#24) can be closed in favor of this clearer workflow definition.
+
+---
+
+*This issue replaces #24 for clarity and practical workflow migration direction.*

--- a/src/README.md
+++ b/src/README.md
@@ -1,34 +1,43 @@
-# WP GitHub Sync
+# WP GitHub Sync + Buttondown
 
-A small GitHub Actions + Node.js toolset that lets you write posts locally (Vim), commit them to your repo, and have GitHub Actions create or update WordPress drafts for PRs and publish on merge to `master`.
+A small GitHub Actions + Node.js toolset that lets you write posts locally, commit them to the repo, and have GitHub Actions sync to WordPress (articles) and create Buttondown draft emails (articles and newsletters).
 
 Overview
-- Create a post at `content/posts/YYYYMMDD_ShortTitle/draft.md` with YAML frontmatter.
-- Optionally include images in the same folder and an `images.yml` with captions/alt text.
-- Open a PR: the workflow creates/updates a draft in WordPress and posts a comment on the PR containing the WP post ID and URL.
-- Merge the PR into `master`: the workflow publishes the post (if frontmatter date is in the future it will be scheduled).
+- Create an article at `content/posts/YYYYMMDD_ShortTitle/draft.md` with YAML frontmatter.
+- Create a newsletter at `content/newsletters/YYYYMMDD_ShortTitle/draft.md` with YAML frontmatter.
+- Optionally include images in the same folder and an `images.yml` with captions/alt text (articles only).
+- **On PR open (articles only):** the workflow creates/updates a draft in WordPress and posts a comment on the PR containing the WP post ID and URL. Newsletter PRs have no WordPress action.
+- **On PR merge:** a Buttondown draft email is created automatically.
+  - Articles: excerpt + link to the WordPress post.
+  - Newsletters: full post content as HTML.
+  - You review the draft in Buttondown and hit Send manually.
 
 Files of interest
-- `.github/workflows/wp-sync.yml` — workflow to run on PR events.
-- `src/index.js` — thin entry point: reads environment, wires the WP client and PR helpers, then delegates to `sync.js`.
-- `src/sync.js` — core sync logic: extracts and uploads images, builds Gutenberg blocks, converts Markdown → HTML, creates/updates WP posts.
+- `.github/workflows/wp-sync.yml` — workflow triggered on PR events (WordPress sync for articles).
+- `.github/workflows/buttondown-sync.yml` — workflow triggered on push to main (Buttondown draft creation).
+- `src/index.js` — entry point: supports `pr` and `merge` modes.
+- `src/sync.js` — core WP sync logic: images, Gutenberg blocks, Markdown → HTML, post create/update.
 - `src/wp-client.js` — WP REST helper.
+- `src/buttondown-client.js` — Buttondown API helper.
+- `src/buttondown-sync.js` — builds Buttondown email content for articles and newsletters.
 - `package.json` — dependencies and `npm test` script.
 
 Frontmatter fields supported (in draft.md)
 - title: string
-- date: ISO 8601 timestamp (used for scheduling on publish)
-- excerpt: short summary
-- tags: [array]
-- categories: [array]
-- featured_image: relative filename in same folder or absolute URL
+- date: ISO 8601 timestamp (used for scheduling on WP publish)
+- excerpt: short summary (included in the article Buttondown email)
+- email_subject: override for the Buttondown email subject line (falls back to title)
+- tags: [array] (articles only — applied as WP tags)
+- categories: [array] (articles only — applied as WP categories)
+- featured_image: relative filename in same folder or absolute URL (articles only)
 
-Example post structure
+Example article structure
 ````markdown name=content/posts/20260224_MyShortTitle/draft.md
 ---
 title: "My Short Title"
 date: 2026-02-24T12:00:00-05:00
-excerpt: "A one-line summary for previews."
+excerpt: "A one-line summary for previews and the Buttondown email."
+email_subject: "[Distracted Fortune] My Short Title"
 tags:
   - idea
   - writing
@@ -37,14 +46,23 @@ categories:
 featured_image: hero.jpg
 ---
 
-Your markdown content here. Include local images with typical markdown:
-![Alt text](hero.jpg)
+Your markdown content here.
+````
 
-Body images are automatically uploaded to the WP Media Library and replaced with
-Gutenberg `<!-- wp:image -->` blocks in the post content, so they render correctly
-in both the Gutenberg editor and the front-end without any manual edits.
-Captions and alt text come from the companion `images.yml` file (alt text written
-in the markdown takes precedence over the `images.yml` value).
+Example newsletter structure
+````markdown name=content/newsletters/20260224_MyNewsletter/draft.md
+---
+title: "My Newsletter"
+date: 2026-02-24T09:00:00-05:00
+email_subject: "[Distracted Fortune] My Newsletter Subject"
+categories:
+  - Newsletter
+---
+
+Good morning!
+
+Full newsletter body here. This goes directly to Buttondown — never to WordPress.
+````
 
 Running tests
 Run `npm test` from the repo root. Tests use Node's built-in test runner (Node ≥ 18

--- a/src/buttondown-client.js
+++ b/src/buttondown-client.js
@@ -1,0 +1,40 @@
+/**
+ * buttondown-client.js — Buttondown API client.
+ *
+ * Wraps the Buttondown v1 REST API for creating draft emails.
+ */
+import axios from 'axios';
+
+const BUTTONDOWN_API_BASE = 'https://api.buttondown.email/v1';
+
+/**
+ * Creates a Buttondown API client.
+ *
+ * @param {{ apiKey: string, _httpClient?: object }} options
+ *   _httpClient is injectable for testing (defaults to axios).
+ * @returns {{ createDraftEmail: Function }}
+ */
+export function buttondownClient({ apiKey, _httpClient = axios }) {
+  const headers = {
+    Authorization: `Token ${apiKey}`,
+    'Content-Type': 'application/json',
+  };
+
+  return {
+    /**
+     * Create a new draft email in Buttondown.
+     *
+     * @param {string} subject
+     * @param {string} body - HTML content
+     * @returns {Promise<{ id: string, absolute_url: string }>}
+     */
+    async createDraftEmail(subject, body) {
+      const res = await _httpClient.post(
+        `${BUTTONDOWN_API_BASE}/emails`,
+        { subject, body, status: 'draft' },
+        { headers },
+      );
+      return res.data;
+    },
+  };
+}

--- a/src/buttondown-sync.js
+++ b/src/buttondown-sync.js
@@ -1,0 +1,66 @@
+/**
+ * buttondown-sync.js — Build Buttondown email content from local markdown drafts.
+ *
+ * Handles two content types:
+ *  - Articles (content/posts/): excerpt + WordPress post link
+ *  - Newsletters (content/newsletters/): full markdown body converted to HTML
+ */
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import rehypeStringify from 'rehype-stringify';
+
+/**
+ * Convert a markdown string to HTML.
+ * @param {string} markdown
+ * @returns {Promise<string>}
+ */
+async function markdownToHtml(markdown) {
+  const vfile = await unified()
+    .use(remarkParse)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeStringify, { allowDangerousHtml: true })
+    .process(markdown);
+  return String(vfile);
+}
+
+/**
+ * Build Buttondown email content for an article.
+ * Sends the excerpt and a link to the full post on WordPress.
+ *
+ * @param {{ title?: string, excerpt?: string, email_subject?: string }} frontmatter
+ * @param {string} wpPostUrl - WordPress post URL
+ * @returns {{ subject: string, body: string }}
+ */
+export function buildArticleEmail(frontmatter, wpPostUrl) {
+  const subject = frontmatter.email_subject || frontmatter.title || 'New post';
+  const excerpt = frontmatter.excerpt || '';
+  const body = [
+    excerpt ? `<p>${excerpt}</p>` : '',
+    `<p><a href="${wpPostUrl}">Read the full post →</a></p>`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+  return { subject, body };
+}
+
+/**
+ * Build Buttondown email content for a newsletter.
+ * Converts the full draft.md body to HTML.
+ *
+ * @param {string} postDir - path to the newsletter directory
+ * @returns {Promise<{ subject: string, body: string }>}
+ */
+export async function buildNewsletterEmail(postDir) {
+  const mdPath = path.join(postDir, 'draft.md');
+  const raw = fs.readFileSync(mdPath, 'utf8');
+  const parsed = matter(raw);
+  const front = parsed.data;
+
+  const subject = front.email_subject || front.title || 'New newsletter';
+  const body = await markdownToHtml(parsed.content);
+  return { subject, body };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,16 +2,22 @@
  * Main sync script entry point.
  *
  * Usage:
- *   node src/index.js pr   # run on pull_request opened/synchronize/reopened
+ *   node src/index.js pr     # run on pull_request opened/synchronize/reopened
+ *   node src/index.js merge  # run on push to main (post-merge Buttondown emails)
  *
- * Reads GITHUB_EVENT_PATH for PR info, GITHUB_TOKEN for comments.
- * Requires WP_URL, WP_USER, WP_APP_PASSWORD in environment.
+ * Reads GITHUB_EVENT_PATH for PR/push info, GITHUB_TOKEN for GitHub API calls.
+ * Requires WP_URL, WP_USER, WP_APP_PASSWORD in environment (pr mode only).
+ * Requires BUTTONDOWN_API_KEY in environment (merge mode only).
  */
 import fs from 'fs';
+import path from 'path';
 import axios from 'axios';
+import matter from 'gray-matter';
 import { wpClient } from './wp-client.js';
 import { createOrUpdateDraftFromDir } from './sync.js';
 import { findPostDirsFromFiles } from './find-post-dirs.js';
+import { buttondownClient } from './buttondown-client.js';
+import { buildArticleEmail, buildNewsletterEmail } from './buttondown-sync.js';
 
 const GITHUB_EVENT_PATH = process.env.GITHUB_EVENT_PATH;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -22,17 +28,6 @@ if (!GITHUB_EVENT_PATH || !fs.existsSync(GITHUB_EVENT_PATH)) {
 }
 
 const event = JSON.parse(fs.readFileSync(GITHUB_EVENT_PATH, 'utf8'));
-
-const WP_URL = process.env.WP_URL;
-const WP_USER = process.env.WP_USER;
-const WP_APP_PASSWORD = process.env.WP_APP_PASSWORD;
-
-if (!WP_URL || !WP_USER || !WP_APP_PASSWORD) {
-  console.error('Missing WP_URL, WP_USER, or WP_APP_PASSWORD in environment.');
-  process.exit(1);
-}
-
-const wp = wpClient({ wpUrl: WP_URL, user: WP_USER, appPassword: WP_APP_PASSWORD });
 
 function makePrHelpers(token, owner, repo) {
   const headers = {
@@ -80,21 +75,121 @@ async function handlePR() {
     console.log('No pull_request in event.');
     return;
   }
+
+  const WP_URL = process.env.WP_URL;
+  const WP_USER = process.env.WP_USER;
+  const WP_APP_PASSWORD = process.env.WP_APP_PASSWORD;
+
+  if (!WP_URL || !WP_USER || !WP_APP_PASSWORD) {
+    console.error('Missing WP_URL, WP_USER, or WP_APP_PASSWORD in environment.');
+    process.exit(1);
+  }
+
+  const wp = wpClient({ wpUrl: WP_URL, user: WP_USER, appPassword: WP_APP_PASSWORD });
+
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
   const filesUrl = `https://api.github.com/repos/${owner}/${repo}/pulls/${pr.number}/files`;
   const filesRes = await axios.get(filesUrl, {
     headers: { Authorization: `token ${GITHUB_TOKEN}`, Accept: 'application/vnd.github.v3+json' },
   });
   const files = filesRes.data.map((f) => f.filename);
-  const postDirs = findPostDirsFromFiles(files);
+  const allDirs = findPostDirsFromFiles(files);
+
+  // Newsletters are not synced to WordPress — only articles go to WP on PR.
+  const postDirs = allDirs.filter((d) => d.startsWith('content/posts/'));
+
   if (postDirs.length === 0) {
-    console.log('No post draft.md changes detected.');
+    console.log('No article draft.md changes detected (newsletters are skipped for WP sync).');
     return;
   }
-  console.log('Post dirs changed:', postDirs);
+  console.log('Article dirs to sync to WP:', postDirs);
   const prHelpers = makePrHelpers(GITHUB_TOKEN, owner, repo);
   for (const postDir of postDirs) {
     await createOrUpdateDraftFromDir(postDir, pr.number, wp, prHelpers);
+  }
+}
+
+/**
+ * Look up the WordPress post URL for a commit by finding the PR that introduced
+ * it and reading the wp-sync mapping stored in PR comments.
+ *
+ * @param {string} sha
+ * @param {string} owner
+ * @param {string} repo
+ * @param {{ readMapping: Function }} prHelpers
+ * @returns {Promise<string|null>}
+ */
+async function lookupWpPostUrl(sha, owner, repo, prHelpers) {
+  try {
+    const url = `https://api.github.com/repos/${owner}/${repo}/commits/${sha}/pulls`;
+    const res = await axios.get(url, {
+      headers: {
+        Authorization: `token ${GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    });
+    const prs = res.data;
+    if (!prs || prs.length === 0) {
+      console.warn(`No PRs found for commit ${sha}`);
+      return null;
+    }
+    const mapping = await prHelpers.readMapping(prs[0].number);
+    return mapping ? mapping.post_url : null;
+  } catch (e) {
+    console.error(`Failed to look up PR for commit ${sha}: ${e.message}`);
+    return null;
+  }
+}
+
+async function handleMerge() {
+  const BUTTONDOWN_API_KEY = process.env.BUTTONDOWN_API_KEY;
+  if (!BUTTONDOWN_API_KEY) {
+    console.error('Missing BUTTONDOWN_API_KEY in environment.');
+    process.exit(1);
+  }
+
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+  const buttondown = buttondownClient({ apiKey: BUTTONDOWN_API_KEY });
+  const prHelpers = makePrHelpers(GITHUB_TOKEN, owner, repo);
+
+  // Collect all changed files across every commit in this push.
+  const commits = event.commits || [];
+  const allFiles = commits.flatMap((c) => [...(c.added || []), ...(c.modified || [])]);
+  const dirs = findPostDirsFromFiles(allFiles);
+
+  if (dirs.length === 0) {
+    console.log('No content draft.md changes detected in push.');
+    return;
+  }
+  console.log('Content dirs changed on merge:', dirs);
+
+  const headSha = event.after || (event.head_commit && event.head_commit.id);
+
+  for (const dir of dirs) {
+    const isNewsletter = dir.startsWith('content/newsletters/');
+
+    if (isNewsletter) {
+      const { subject, body } = await buildNewsletterEmail(dir);
+      const draft = await buttondown.createDraftEmail(subject, body);
+      console.log(`Created Buttondown draft for newsletter ${dir}: ${draft.absolute_url || draft.id}`);
+    } else {
+      // Article: retrieve the WP post URL from the merged PR's comment mapping.
+      const wpPostUrl = headSha
+        ? await lookupWpPostUrl(headSha, owner, repo, prHelpers)
+        : null;
+
+      if (!wpPostUrl) {
+        console.warn(`Could not find WP post URL for ${dir} — skipping Buttondown email.`);
+        continue;
+      }
+
+      const mdPath = path.join(dir, 'draft.md');
+      const raw = fs.readFileSync(mdPath, 'utf8');
+      const front = matter(raw).data;
+      const { subject, body } = buildArticleEmail(front, wpPostUrl);
+      const draft = await buttondown.createDraftEmail(subject, body);
+      console.log(`Created Buttondown draft for article ${dir}: ${draft.absolute_url || draft.id}`);
+    }
   }
 }
 
@@ -102,8 +197,10 @@ async function run() {
   const mode = process.argv[2];
   if (mode === 'pr') {
     await handlePR();
+  } else if (mode === 'merge') {
+    await handleMerge();
   } else {
-    console.error('Unknown mode. Use "pr".');
+    console.error('Unknown mode. Use "pr" or "merge".');
     process.exit(1);
   }
 }

--- a/test/fixtures/02_simple_newsletter/draft.md
+++ b/test/fixtures/02_simple_newsletter/draft.md
@@ -1,0 +1,15 @@
+---
+title: "Test Newsletter"
+date: 2026-01-15T09:00:00-05:00
+email_subject: "[Distracted Fortune] Test Newsletter Subject"
+categories:
+  - Newsletter
+---
+
+Good morning!
+
+This is the body of a test newsletter. It has **bold text** and a [link](https://example.com).
+
+Thanks for reading. Now, get back to work.
+
+Peter

--- a/test/should_build_buttondown_emails.test.js
+++ b/test/should_build_buttondown_emails.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildArticleEmail, buildNewsletterEmail } from '../src/buttondown-sync.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const NEWSLETTER_FIXTURE = path.join(__dirname, 'fixtures', '02_simple_newsletter');
+const ARTICLE_FIXTURE = path.join(__dirname, 'fixtures', '01_simple_post');
+
+// ---------------------------------------------------------------------------
+// buildArticleEmail
+// ---------------------------------------------------------------------------
+
+test('should_use_email_subject_field_when_present', () => {
+  const front = { email_subject: '[DF] Custom Subject', title: 'My Title', excerpt: 'Short summary.' };
+  const { subject } = buildArticleEmail(front, 'https://example.com/post');
+  assert.equal(subject, '[DF] Custom Subject');
+});
+
+test('should_fall_back_to_title_when_no_email_subject', () => {
+  const front = { title: 'My Title', excerpt: 'Short summary.' };
+  const { subject } = buildArticleEmail(front, 'https://example.com/post');
+  assert.equal(subject, 'My Title');
+});
+
+test('should_include_excerpt_in_article_body', () => {
+  const front = { title: 'My Title', excerpt: 'A short teaser.' };
+  const { body } = buildArticleEmail(front, 'https://example.com/post');
+  assert.ok(body.includes('A short teaser.'), 'body should contain the excerpt');
+});
+
+test('should_include_wp_link_in_article_body', () => {
+  const front = { title: 'My Title', excerpt: 'A short teaser.' };
+  const { body } = buildArticleEmail(front, 'https://example.com/post');
+  assert.ok(body.includes('https://example.com/post'), 'body should contain the WP post URL');
+});
+
+test('should_omit_excerpt_paragraph_when_excerpt_is_empty', () => {
+  const front = { title: 'My Title' };
+  const { body } = buildArticleEmail(front, 'https://example.com/post');
+  assert.ok(!body.includes('<p></p>'), 'should not include empty excerpt paragraph');
+  assert.ok(body.includes('https://example.com/post'), 'should still include the post link');
+});
+
+// ---------------------------------------------------------------------------
+// buildNewsletterEmail
+// ---------------------------------------------------------------------------
+
+test('should_use_email_subject_from_frontmatter_for_newsletter', async () => {
+  const { subject } = await buildNewsletterEmail(NEWSLETTER_FIXTURE);
+  assert.equal(subject, '[Distracted Fortune] Test Newsletter Subject');
+});
+
+test('should_convert_newsletter_body_to_html', async () => {
+  const { body } = await buildNewsletterEmail(NEWSLETTER_FIXTURE);
+  assert.ok(body.includes('<strong>bold text</strong>'), 'body should render bold markdown as HTML');
+});
+
+test('should_include_newsletter_link_as_anchor_tag', async () => {
+  const { body } = await buildNewsletterEmail(NEWSLETTER_FIXTURE);
+  assert.ok(
+    body.includes('<a href="https://example.com">link</a>'),
+    'body should render markdown links as anchor tags',
+  );
+});

--- a/test/should_create_buttondown_draft.test.js
+++ b/test/should_create_buttondown_draft.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buttondownClient } from '../src/buttondown-client.js';
+
+test('should_post_draft_email_to_buttondown_api', async () => {
+  const requests = [];
+  const fakeHttp = {
+    async post(url, data, options) {
+      requests.push({ url, data, options });
+      return { data: { id: 'abc-123', absolute_url: 'https://buttondown.email/emails/abc-123' } };
+    },
+  };
+
+  const client = buttondownClient({ apiKey: 'test-key', _httpClient: fakeHttp });
+  const result = await client.createDraftEmail('My Subject', '<p>Hello</p>');
+
+  assert.equal(requests.length, 1, 'should make exactly one HTTP request');
+  assert.ok(requests[0].url.includes('/emails'), 'should call the /emails endpoint');
+  assert.equal(result.id, 'abc-123');
+});
+
+test('should_send_status_draft_in_request_body', async () => {
+  const requests = [];
+  const fakeHttp = {
+    async post(url, data, options) {
+      requests.push({ url, data, options });
+      return { data: { id: 'xyz-456' } };
+    },
+  };
+
+  const client = buttondownClient({ apiKey: 'test-key', _httpClient: fakeHttp });
+  await client.createDraftEmail('Subject', '<p>Body</p>');
+
+  assert.equal(requests[0].data.status, 'draft', 'status must be draft');
+  assert.equal(requests[0].data.subject, 'Subject');
+  assert.equal(requests[0].data.body, '<p>Body</p>');
+});
+
+test('should_use_token_auth_header', async () => {
+  const requests = [];
+  const fakeHttp = {
+    async post(url, data, options) {
+      requests.push({ url, data, options });
+      return { data: { id: 'xyz-456' } };
+    },
+  };
+
+  const client = buttondownClient({ apiKey: 'secret-api-key', _httpClient: fakeHttp });
+  await client.createDraftEmail('Subject', '<p>Body</p>');
+
+  assert.equal(
+    requests[0].options.headers.Authorization,
+    'Token secret-api-key',
+    'Authorization header must use Token scheme',
+  );
+});


### PR DESCRIPTION
- Filter content/newsletters/ dirs from WordPress sync on PR
- Add Buttondown client and email builders for articles and newsletters
- Add merge-mode handler: creates Buttondown draft emails on push to main
  - Articles: excerpt + WP post link (URL looked up from merged PR comment)
  - Newsletters: full HTML content
- Add buttondown-sync.yml workflow triggered on push to main/master
- Add 10 new tests; all 37 pass

Closes #28