### PR TITLE
fix(merge): use GitHub Compare API to detect changed files on push

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,9 +152,30 @@ async function handleMerge() {
   const buttondown = buttondownClient({ apiKey: BUTTONDOWN_API_KEY });
   const prHelpers = makePrHelpers(GITHUB_TOKEN, owner, repo);
 
-  // Collect all changed files across every commit in this push.
-  const commits = event.commits || [];
-  const allFiles = commits.flatMap((c) => [...(c.added || []), ...(c.modified || [])]);
+  // Collect all changed files. Merge commits have empty added/modified arrays
+  // in the push event payload, so prefer the GitHub Compare API. Fall back to
+  // commit file lists only when the Compare API is unavailable.
+  const before = event.before;
+  const after = event.after;
+  let allFiles;
+  if (GITHUB_TOKEN && before && after && !/^0+$/.test(before)) {
+    try {
+      const headers = {
+        Authorization: `token ${GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github.v3+json',
+      };
+      const url = `https://api.github.com/repos/${owner}/${repo}/compare/${before}...${after}`;
+      const res = await axios.get(url, { headers });
+      allFiles = (res.data.files || [])
+        .filter((f) => f.status === 'added' || f.status === 'modified')
+        .map((f) => f.filename);
+    } catch (e) {
+      console.warn(`Compare API failed (${e.message}), falling back to commit file lists.`);
+      allFiles = (event.commits || []).flatMap((c) => [...(c.added || []), ...(c.modified || [])]);
+    }
+  } else {
+    allFiles = (event.commits || []).flatMap((c) => [...(c.added || []), ...(c.modified || [])]);
+  }
   const dirs = findPostDirsFromFiles(allFiles);
 
   if (dirs.length === 0) {

--- a/test/should_find_post_dirs_from_files.test.js
+++ b/test/should_find_post_dirs_from_files.test.js
@@ -34,3 +34,42 @@ test('should_deduplicate_the_same_draft_file', () => {
   ]);
   assert.deepEqual(dirs, ['content/posts/my-post']);
 });
+
+// ---------------------------------------------------------------------------
+// Simulated GitHub Compare API payloads (res.data.files[].filename / .status)
+// Merge commits have empty added/modified arrays in the push event, so
+// handleMerge() uses the Compare API and applies filter+map before calling
+// findPostDirsFromFiles.
+// ---------------------------------------------------------------------------
+
+function filesFromCompareApi(compareFiles) {
+  return compareFiles
+    .filter((f) => f.status === 'added' || f.status === 'modified')
+    .map((f) => f.filename);
+}
+
+test('should_detect_newsletter_draft_added_via_compare_api', () => {
+  const files = filesFromCompareApi([
+    { filename: 'content/newsletters/20260524_KanbanHomework/draft.md', status: 'added' },
+    { filename: 'README.md', status: 'modified' },
+  ]);
+  const dirs = findPostDirsFromFiles(files);
+  assert.deepEqual(dirs, ['content/newsletters/20260524_KanbanHomework']);
+});
+
+test('should_ignore_removed_files_from_compare_api', () => {
+  const files = filesFromCompareApi([
+    { filename: 'content/newsletters/20260524_KanbanHomework/draft.md', status: 'removed' },
+  ]);
+  const dirs = findPostDirsFromFiles(files);
+  assert.deepEqual(dirs, []);
+});
+
+test('should_detect_post_draft_modified_via_compare_api', () => {
+  const files = filesFromCompareApi([
+    { filename: 'content/posts/my-post/draft.md', status: 'modified' },
+    { filename: 'content/posts/my-post/image.png', status: 'added' },
+  ]);
+  const dirs = findPostDirsFromFiles(files);
+  assert.deepEqual(dirs, ['content/posts/my-post']);
+});


### PR DESCRIPTION
event.commits[].added/modified is empty for merge commits; the Compare API (/compare/{before}...{after}) correctly surfaces all changed files. Falls back to commit file lists when the API is unavailable.

Fixes #28