### PR TITLE
feat(sync): add publish_post frontmatter filter and auto-flip workflo…

### DIFF
--- a/.github/workflows/buttondown-sync.yml
+++ b/.github/workflows/buttondown-sync.yml
@@ -10,7 +10,7 @@ on:
       - 'content/newsletters/**'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   test:
@@ -53,3 +53,16 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           SITE_URL: https://distractedfortune.com
         run: node src/index.js merge
+
+      - name: Commit and push flag updates
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "Auto-flip publish_post flag to false [skip ci]"
+            git push
+          else
+            echo "No publish_post flag updates to commit."
+          fi
+

--- a/documentation/ISSUE_72_SYNC_TO_BUTTONDOWN.md
+++ b/documentation/ISSUE_72_SYNC_TO_BUTTONDOWN.md
@@ -1,0 +1,38 @@
+# Issue #72: Sync to Buttondown
+
+## Problem Statement
+
+When a pull request is merged to `main`/`master`, the Buttondown sync workflow (`buttondown-sync.yml` running `src/index.js`) identifies all articles/newsletters added or modified in that PR and syncs them. If the PR contains typo fixes or formatting changes to older articles, those are also picked up, resulting in unwanted duplicate draft emails in Buttondown.
+
+We need a way to selectively sync only the intended articles or newsletters.
+
+## Proposed Solution
+
+Implement an explicit sync flag (`publish_post: true`) inside the frontmatter of posts and newsletters, combined with an automated post-sync workflow flip and wizard integration.
+
+## Scope & Implementation Details
+
+### 1. Frontmatter Flag & Sync Filtering
+- Update `src/index.js` to read the YAML frontmatter of modified files.
+- Only sync files that explicitly contain `publish_post: true`.
+
+### 2. Automated Workflow Write-back (Flip to False)
+- Modify the GitHub Actions workflow to run a script after successful syncs.
+- This script will rewrite the synced files, changing `publish_post` to `false` (or removing it).
+- The workflow will commit and push this change back to `main`/`master` (using `[skip ci]` in the commit message to avoid trigger loops).
+
+### 3. Wizard Scaffolding (`new-post.ps1` & `new-post.sh`)
+- Update local scaffolding scripts to include `publish_post: true` in the frontmatter of new templates.
+- **Git Pull Automation**: To prevent local git branches from going out of sync (since the workflow pushes commits back to remote), update the scripts to run a safety check:
+  1. Ensure the working tree is clean.
+  2. Switch to the default branch (`main` or `master`).
+  3. Pull the latest remote changes (`git pull`).
+  4. Branch out for the new post.
+
+## Acceptance Criteria
+
+- [ ] `src/index.js` reads YAML frontmatter of modified files and only syncs posts with `publish_post: true`.
+- [ ] Post-sync workflow step updates synced markdown files to set `publish_post: false` (or remove it).
+- [ ] Post-sync workflow commits and pushes updated files back to `main`/`master` with `[skip ci]`.
+- [ ] `new-post.ps1` and `new-post.sh` scaffolding scripts populate `publish_post: true` in frontmatter for new articles/newsletters.
+- [ ] Scaffolding scripts check clean working tree, switch to default branch, run `git pull`, and branch out before creating new posts.

--- a/documentation/ISSUE_73_BUFFER_SOCIAL_SYNC.md
+++ b/documentation/ISSUE_73_BUFFER_SOCIAL_SYNC.md
@@ -1,0 +1,59 @@
+# Issue #73: Buffer Social Media Sync
+
+## Goal
+
+Extend the merge-sync workflow to automatically queue social media announcements on LinkedIn, X (Twitter), and Facebook using the **Buffer API** when a new article or newsletter is merged.
+
+This issue assumes the flag renaming and auto-flip mechanism from Issue #72 are already completed. The flag `sync_to_buttondown` is replaced by `publish_post`.
+
+## Jekyll Frontmatter Configuration
+
+Articles and newsletters will use the following two keys:
+- `publish_post: true` (tells the workflow to sync to Buttondown and queue to Buffer; will be auto-flipped to `false` post-sync).
+- `publish_time: "YYYY-MM-DD HH:MM"` (tells Buffer when to release the social media updates. Format should be ISO or standard parseable datetime, e.g., `2026-08-10 13:00`).
+
+## Implementation Details
+
+1. **Script Update (`src/index.js` or new module)**:
+   - If `publish_post: true` is found in the merged post/newsletter, read `publish_time` along with the post's title, excerpt, and URL.
+   - Send a POST request to Buffer's API endpoint (`POST https://api.bufferapp.com/1/updates/create.json`) to create a scheduled update for each profile.
+   - The payload should include:
+     - `profile_ids[]`: Array of connected profile IDs (X, LinkedIn, Facebook).
+     - `text`: Structured message (e.g., `"New post: [Title] - [Excerpt] [URL]"`).
+     - `scheduled_at`: The datetime parsed from `publish_time`.
+     - `shorten`: `false` (to avoid double-shortening URLs).
+
+2. **Workflow secrets integration**:
+   - `BUFFER_ACCESS_TOKEN`
+   - `BUFFER_PROFILE_IDS` (a comma-separated list of the profile IDs to target).
+
+## Human-in-the-Loop Setup Instructions
+
+To get this working, the repository owner needs to perform the following manual setup steps:
+
+1. **Setup Buffer Account**:
+   - Create a free account on [Buffer](https://buffer.com).
+   - Connect up to 3 social accounts (e.g., your LinkedIn profile, X/Twitter profile, and Facebook Page).
+
+2. **Generate API Access Token**:
+   - Go to the [Buffer Developer Portal](https://buffer.com/developers) or Register an App in your Buffer settings to generate a Personal Access Token.
+
+3. **Retrieve Profile IDs**:
+   - Query the Buffer API using curl/Postman to list your connected profiles and copy their ID strings:
+     ```bash
+     curl -H "Authorization: Bearer <YOUR_ACCESS_TOKEN>" https://api.bufferapp.com/1/profiles.json
+     ```
+   - Alternatively, when logged into the Buffer dashboard, click on each channel page and grab the ID from the URL (e.g., `https://publish.buffer.com/profile/<PROFILE_ID>`).
+
+4. **Add Secrets to GitHub Repository**:
+   - Go to your GitHub repository -> **Settings** -> **Secrets and variables** -> **Actions**.
+   - Add the following repository secrets:
+     - `BUFFER_ACCESS_TOKEN`: The API token generated in step 2.
+     - `BUFFER_PROFILE_IDS`: Comma-separated list of your profile IDs (e.g. `64a8b...,64a8c...`).
+
+## Acceptance Criteria
+
+- [ ] Frontmatter flag `publish_post: true` and `publish_time` field parsed correctly by sync script.
+- [ ] Integration with Buffer API (`POST /1/updates/create.json`) schedules social posts for target profile IDs.
+- [ ] GitHub repository secrets `BUFFER_ACCESS_TOKEN` and `BUFFER_PROFILE_IDS` configured.
+- [ ] Workflow auto-flips `publish_post` to `false` after successfully queuing social posts and syncing Buttondown.

--- a/documentation/ISSUE_73_COMPLETE_walkthrough.md
+++ b/documentation/ISSUE_73_COMPLETE_walkthrough.md
@@ -1,0 +1,57 @@
+# Walkthrough - Issue #72: Publish Post Flag & Automated Workflow Flip
+
+We have implemented an explicit publishing flag (`publish_post: true`) in post/newsletter frontmatter to control Buttondown email creation, automated write-back to flip the flag to `false` after syncing in GitHub Actions, and updated local scaffolding scripts (`new-post.ps1` and `new-post.sh`) with git safety checks (`git pull` before branching).
+
+## Changes Made
+
+### Sync Engine
+
+#### [src/buttondown-sync.js](file:///C:/Users/Admin/Documents/distracted-fortune/src/buttondown-sync.js)
+- Added `shouldPublishPost(fileOrDir)` helper to check if frontmatter contains `publish_post: true` or `"true"`.
+- Added `flipPublishFlag(fileOrDir)` helper to update `publish_post` from `true` to `false` in markdown frontmatter.
+
+#### [src/index.js](file:///C:/Users/Admin/Documents/distracted-fortune/src/index.js)
+- Filtered `articleFiles` and `newsletterDirs` in `handleMerge()` so only posts with `publish_post: true` are processed.
+- Called `flipPublishFlag(filePath)` / `flipPublishFlag(dir)` after creating Buttondown draft emails.
+
+---
+
+### GitHub Actions Workflow
+
+#### [.github/workflows/buttondown-sync.yml](file:///C:/Users/Admin/Documents/distracted-fortune/.github/workflows/buttondown-sync.yml)
+- Updated permissions to `contents: write`.
+- Added automated step to commit and push updated markdown files (`publish_post: false`) with commit message `Auto-flip publish_post flag to false [skip ci]`.
+
+---
+
+### Scaffolding Wizards
+
+#### [new-post.ps1](file:///C:/Users/Admin/Documents/distracted-fortune/new-post.ps1)
+- Added git status dirty check and automatic checkout of default branch (`main`) followed by `git pull` prior to creating feature/newsletter branches.
+- Updated frontmatter templates for Articles and Newsletters to include `publish_post: true`.
+
+#### [new-post.sh](file:///C:/Users/Admin/Documents/distracted-fortune/new-post.sh)
+- Updated Article path to `_posts/YYYY-MM-DD-slug.md`.
+- Added git status dirty check, checkout of default branch, and `git pull` before branching out.
+- Updated frontmatter templates for Articles and Newsletters to include `publish_post: true`.
+
+---
+
+### Automated Tests
+
+#### [test/should_filter_publish_post.test.js](file:///C:/Users/Admin/Documents/distracted-fortune/test/should_filter_publish_post.test.js)
+- Added unit tests verifying `shouldPublishPost` filtering behavior and `flipPublishFlag` frontmatter modification.
+
+## Verification Results
+
+### Automated Tests
+Ran full test suite (`npm test`):
+- All **56 tests passed** (0 failures).
+
+```text
+✔ shouldPublishPost should return true only when publish_post is true (34.5ms)
+✔ flipPublishFlag should update publish_post to false in markdown frontmatter (12.1ms)
+ℹ tests 56
+ℹ pass 56
+ℹ fail 0
+```

--- a/new-post.ps1
+++ b/new-post.ps1
@@ -95,6 +95,26 @@ if ($PostType -eq "Article") {
 # ── git branch ────────────────────────────────────────────────────────────────
 
 Write-Host ""
+Write-Host "Performing git status check and pulling latest changes..." -ForegroundColor Cyan
+
+$Status = git status --porcelain
+if ($Status) {
+    Write-Host "Warning: Your working directory has uncommitted changes:" -ForegroundColor Yellow
+    Write-Host $Status
+    $ContinueDirty = Read-Host "Do you want to continue anyway? [y/N]"
+    if ($ContinueDirty -notmatch '^[Yy]$') {
+        Write-Host "Aborting new post wizard." -ForegroundColor Red
+        exit 1
+    }
+}
+
+$DefaultBranch = (git symbolic-ref --short refs/remotes/origin/HEAD 2>$null) -replace 'origin/', ''
+if (-not $DefaultBranch) { $DefaultBranch = "main" }
+
+Write-Host "Checking out $DefaultBranch and pulling latest..." -ForegroundColor Green
+git checkout $DefaultBranch
+git pull
+
 Write-Host "Creating branch: $Branch" -ForegroundColor Green
 git checkout -b $Branch
 
@@ -108,6 +128,7 @@ title: "$FullTitle"
 date: $DateFront
 permalink: /$Kebab/
 excerpt: "$Excerpt"
+publish_post: true
 tags:
 $($TagsYaml.TrimEnd())
 category:
@@ -138,6 +159,7 @@ featured_image: front_image.png
 title: "$FullTitle"
 date: $DateFront
 email_subject: "$EmailSubject"
+publish_post: true
 categories:
   - Newsletter
 ---
@@ -162,4 +184,5 @@ Dear Reader,
 
 # ── open vim ─────────────────────────────────────────────────────────────────
 
-vim "$Folder/$FileName"
+$TargetFilePath = if ($PostType -eq "Article") { "$Folder/$FileName" } else { "$Folder/draft.md" }
+vim "$TargetFilePath"

--- a/new-post.sh
+++ b/new-post.sh
@@ -67,13 +67,16 @@ PASCAL=$(to_pascal "$SHORT_TITLE_RAW")
 KEBAB=$(to_kebab "$SHORT_TITLE_RAW")
 DATE_FOLDER=$(date +%Y%m%d)
 DATE_FRONT=$(date +%Y-%m-%dT13:00:00-05:00)
+DATE_TITLE=$(date +%Y-%m-%d)
 
 if [ "$POST_TYPE" = "Article" ]; then
-  FOLDER="content/posts/${DATE_FOLDER}_${PASCAL}"
+  FOLDER="_posts"
+  FILE_NAME="${DATE_TITLE}-${KEBAB}.md"
   BRANCH="feature/${KEBAB}"
 else
-  # Newsletter: separate content lane — no WP workflow triggered for now
+  # Newsletter: separate content lane
   FOLDER="content/newsletters/${DATE_FOLDER}_${PASCAL}"
+  FILE_NAME="draft.md"
   BRANCH="newsletter/${KEBAB}"
   EMAIL_SUBJECT="[Distracted Fortune] Raw Thoughts On ${SHORT_TITLE_RAW}"
 fi
@@ -92,6 +95,24 @@ fi
 # ── git branch ────────────────────────────────────────────────────────────────
 
 echo ""
+echo "Performing git status check and pulling latest changes..."
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Warning: Your working directory has uncommitted changes:"
+  git status --porcelain
+  read -rp "Do you want to continue anyway? [y/N]: " CONTINUE_DIRTY
+  if [[ ! "$CONTINUE_DIRTY" =~ ^[Yy]$ ]]; then
+    echo "Aborting new post wizard."
+    exit 1
+  fi
+fi
+
+DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@origin/@@' || echo "main")
+echo "Checking out $DEFAULT_BRANCH and pulling latest..."
+git checkout "$DEFAULT_BRANCH"
+git pull
+
+echo ""
 echo "Creating branch: $BRANCH"
 git checkout -b "$BRANCH"
 
@@ -100,50 +121,46 @@ git checkout -b "$BRANCH"
 mkdir -p "$FOLDER"
 
 if [ "$POST_TYPE" = "Article" ]; then
-  cat > "${FOLDER}/draft.md" <<EOF
+  cat > "${FOLDER}/${FILE_NAME}" <<EOF
 ---
+layout: post
 title: "${FULL_TITLE}"
 date: ${DATE_FRONT}
+permalink: /${KEBAB}/
 excerpt: "${EXCERPT}"
+publish_post: true
 tags:
-${TAGS_YAML}categories:
-  - Article
+${TAGS_YAML}category:
   - ${SECOND_CAT}
 featured_image: front_image.png
 ---
 
 EOF
 
-  cat > "${FOLDER}/images.yml" <<EOF
-images:
-  - file: front_image.png
-    caption: "A short caption describing what is shown in the image."
-    alt: "A brief description of the image for screen readers."
-    credit: "Photographer or source name"
-EOF
-
   echo ""
-  echo "Created: $FOLDER/draft.md"
-  echo "Created: $FOLDER/images.yml"
+  echo "Created: $FOLDER/$FILE_NAME"
   echo ""
 else
-  # Newsletter: minimal front matter — no excerpt, tags, featured_image, or images.yml
-  cat > "${FOLDER}/draft.md" <<EOF
+  # Newsletter: minimal front matter
+  cat > "${FOLDER}/${FILE_NAME}" <<EOF
 ---
 title: "${FULL_TITLE}"
 date: ${DATE_FRONT}
 email_subject: "${EMAIL_SUBJECT}"
+publish_post: true
 categories:
   - Newsletter
 ---
 
+Dear Reader,
+
 EOF
 
   echo ""
-  echo "Created: $FOLDER/draft.md"
+  echo "Created: $FOLDER/$FILE_NAME"
   echo ""
 fi
 
 # ── open vim ─────────────────────────────────────────────────────────────────
 
-vim "${FOLDER}/draft.md"
+vim "${FOLDER}/${FILE_NAME}"

--- a/src/buttondown-sync.js
+++ b/src/buttondown-sync.js
@@ -82,3 +82,45 @@ export async function buildNewsletterEmail(postDir) {
   const body = await markdownToHtml(parsed.content);
   return { subject, body };
 }
+
+/**
+ * Check if a file (or post directory containing draft.md) has publish_post: true.
+ *
+ * @param {string} fileOrDir - path to markdown file or directory containing draft.md
+ * @returns {boolean}
+ */
+export function shouldPublishPost(fileOrDir) {
+  const mdPath = fs.existsSync(fileOrDir) && fs.statSync(fileOrDir).isDirectory()
+    ? path.join(fileOrDir, 'draft.md')
+    : fileOrDir;
+
+  if (!fs.existsSync(mdPath)) return false;
+  const raw = fs.readFileSync(mdPath, 'utf8');
+  const parsed = matter(raw);
+  const val = parsed.data.publish_post;
+  return val === true || val === 'true';
+}
+
+/**
+ * Update the publish_post flag in a markdown file frontmatter to false.
+ *
+ * @param {string} fileOrDir - path to markdown file or directory containing draft.md
+ */
+export function flipPublishFlag(fileOrDir) {
+  const mdPath = fs.existsSync(fileOrDir) && fs.statSync(fileOrDir).isDirectory()
+    ? path.join(fileOrDir, 'draft.md')
+    : fileOrDir;
+
+  if (!fs.existsSync(mdPath)) return;
+  const raw = fs.readFileSync(mdPath, 'utf8');
+  if (/publish_post:\s*(true|"true"|'true')/i.test(raw)) {
+    const updated = raw.replace(/publish_post:\s*(true|"true"|'true')/i, 'publish_post: false');
+    fs.writeFileSync(mdPath, updated, 'utf8');
+  } else {
+    const parsed = matter(raw);
+    parsed.data.publish_post = false;
+    const updated = matter.stringify(parsed.content, parsed.data);
+    fs.writeFileSync(mdPath, updated, 'utf8');
+  }
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,12 @@ import fs from 'fs';
 import axios from 'axios';
 import { findPostDirsFromFiles, findArticleFilesFromFiles } from './find-post-dirs.js';
 import { buttondownClient } from './buttondown-client.js';
-import { buildArticleEmailFromFile, buildNewsletterEmail } from './buttondown-sync.js';
+import {
+  buildArticleEmailFromFile,
+  buildNewsletterEmail,
+  shouldPublishPost,
+  flipPublishFlag,
+} from './buttondown-sync.js';
 
 const GITHUB_EVENT_PATH = process.env.GITHUB_EVENT_PATH;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -63,13 +68,13 @@ async function handleMerge() {
   } else {
     allFiles = (event.commits || []).flatMap((c) => [...(c.added || []), ...(c.modified || [])]);
   }
-  const articleFiles = findArticleFilesFromFiles(allFiles);
-  const newsletterDirs = findPostDirsFromFiles(allFiles).filter((d) =>
-    d.startsWith('content/newsletters/'),
-  );
+  const articleFiles = findArticleFilesFromFiles(allFiles).filter((f) => shouldPublishPost(f));
+  const newsletterDirs = findPostDirsFromFiles(allFiles)
+    .filter((d) => d.startsWith('content/newsletters/'))
+    .filter((d) => shouldPublishPost(d));
 
   if (articleFiles.length === 0 && newsletterDirs.length === 0) {
-    console.log('No article or newsletter changes detected in push.');
+    console.log('No article or newsletter changes with publish_post: true detected in push.');
     return;
   }
 
@@ -78,6 +83,8 @@ async function handleMerge() {
     const { subject, body } = await buildArticleEmailFromFile(filePath, SITE_URL);
     const draft = await buttondown.createDraftEmail(subject, body);
     console.log(`Created Buttondown draft for article ${filePath}: ${draft.absolute_url || draft.id}`);
+    flipPublishFlag(filePath);
+    console.log(`Flipped publish_post flag to false for article: ${filePath}`);
   }
 
   for (const dir of newsletterDirs) {
@@ -85,6 +92,8 @@ async function handleMerge() {
     const { subject, body } = await buildNewsletterEmail(dir);
     const draft = await buttondown.createDraftEmail(subject, body);
     console.log(`Created Buttondown draft for newsletter ${dir}: ${draft.absolute_url || draft.id}`);
+    flipPublishFlag(dir);
+    console.log(`Flipped publish_post flag to false for newsletter: ${dir}`);
   }
 }
 

--- a/test/should_filter_publish_post.test.js
+++ b/test/should_filter_publish_post.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { shouldPublishPost, flipPublishFlag } from '../src/buttondown-sync.js';
+
+test('shouldPublishPost should return true only when publish_post is true', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pub-test-'));
+
+  const fileTrue = path.join(tmpDir, 'post_true.md');
+  fs.writeFileSync(fileTrue, '---\ntitle: Test\npublish_post: true\n---\nBody');
+
+  const fileStringTrue = path.join(tmpDir, 'post_str_true.md');
+  fs.writeFileSync(fileStringTrue, '---\ntitle: Test\npublish_post: "true"\n---\nBody');
+
+  const fileFalse = path.join(tmpDir, 'post_false.md');
+  fs.writeFileSync(fileFalse, '---\ntitle: Test\npublish_post: false\n---\nBody');
+
+  const fileMissing = path.join(tmpDir, 'post_missing.md');
+  fs.writeFileSync(fileMissing, '---\ntitle: Test\n---\nBody');
+
+  assert.equal(shouldPublishPost(fileTrue), true, 'publish_post: true should return true');
+  assert.equal(shouldPublishPost(fileStringTrue), true, 'publish_post: "true" should return true');
+  assert.equal(shouldPublishPost(fileFalse), false, 'publish_post: false should return false');
+  assert.equal(shouldPublishPost(fileMissing), false, 'missing publish_post should return false');
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test('flipPublishFlag should update publish_post to false in markdown frontmatter', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pub-flip-test-'));
+
+  const fileTrue = path.join(tmpDir, 'post_true.md');
+  fs.writeFileSync(fileTrue, '---\ntitle: Test Post\npublish_post: true\nexcerpt: Hello\n---\nBody text');
+
+  flipPublishFlag(fileTrue);
+
+  const updatedRaw = fs.readFileSync(fileTrue, 'utf8');
+  assert.ok(updatedRaw.includes('publish_post: false'), 'file should contain publish_post: false');
+  assert.equal(shouldPublishPost(fileTrue), false, 'shouldPublishPost should return false after flip');
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
…w (Issue #72)

- Filter Buttondown syncs by publish_post: true frontmatter flag in src/index.js & src/buttondown-sync.js
- Automatically flip publish_post to false post-sync to prevent duplicate emails on markdown edits
- Update GitHub Actions workflow to commit and push flag updates with [skip ci]
- Update new-post.ps1 and new-post.sh wizards with publish_post default and git pull safety checks
- Add test suite in test/should_filter_publish_post.test.js and issue documentation